### PR TITLE
docs: require a DCO signoff

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,17 @@
 <!--
 Fill in the relevant information below to help triage your issue.
+
 Pick the target branch based on the following criteria:
   * Documentation improvement: master branch
   * Bugfix: master branch
   * QA improvement (additional tests, CS fixes, etc.) that does not change code
     behavior: master branch
   * New feature, or refactor of existing code: develop branch
+
+You MUST provide a signoff in your commits for us to be able to accept your
+patch; you can do this by providing either the --signoff or -s flag when using
+"git commit". Please see the project contributing guide and
+https://developercertificate.org for details.
 -->
 
 |    Q          |   A

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,8 +129,20 @@ Switched to a new branch 'hotfix/9295'
 
 
 ```console
-$ git commit
+$ git commit -s
 ```
+
+> ### About the -s flag
+>
+> In order for us to accept your patches, you must provide a signoff in all
+> commits; this is done by using the `-s` or `--signoff` option when calling
+> `git commit`. The signoff is used to certify that you have rights to submit
+> your patch under the project's license, and that you agree to the [Developer
+> Certificate of Origin](https://developercertificate.org).
+>
+> You can automate inclusion of the `-s` or `--signoff` option by creating a
+> local alias with the command `git config alias.commit "commit -s"`. (If you
+> use an alias such as `ci` normally, create an equivalent alias.)
 
 ... write your log message ...
 


### PR DESCRIPTION
In order for us to operate under the Linux Foundation, we need new
commits to have a --signoff, which will indicate the contributor's
agreement to the Developer Certificate of Origin
(https://developercertificate.org).

Once this patch is in place, I will enable a DCO verification app in the
organization.
